### PR TITLE
Feat/#8/place domain 구현

### DIFF
--- a/src/main/java/com/example/taggo/domain/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/taggo/domain/common/config/SecurityConfig.java
@@ -16,11 +16,12 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable) // REST API에서 보통 꺼둠
+                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/v1/user/register",
-                                "/api/v1/user/login"
+                                "/api/v1/user/login",
+                                "/api/v1/search"
                         ).permitAll()
                         .anyRequest().authenticated()
                 );

--- a/src/main/java/com/example/taggo/domain/kakao/api/controller/KakaoApiController.java
+++ b/src/main/java/com/example/taggo/domain/kakao/api/controller/KakaoApiController.java
@@ -1,0 +1,25 @@
+package com.example.taggo.domain.kakao.api.controller;
+
+import com.example.taggo.domain.kakao.api.response.SearchResultListResponse;
+import com.example.taggo.domain.kakao.service.KakaoApiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/search")
+@RequiredArgsConstructor
+public class KakaoApiController {
+
+    private final KakaoApiService kakaoApiService;
+
+    @GetMapping
+    public ResponseEntity<SearchResultListResponse> search(@RequestParam String query) {
+        return ResponseEntity.ok(kakaoApiService.keywordSearch(query));
+    }
+}

--- a/src/main/java/com/example/taggo/domain/kakao/api/response/SearchResultListResponse.java
+++ b/src/main/java/com/example/taggo/domain/kakao/api/response/SearchResultListResponse.java
@@ -1,0 +1,11 @@
+package com.example.taggo.domain.kakao.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record SearchResultListResponse(
+        @JsonProperty("documents")
+        List<SearchResultResponse> result
+) {
+}

--- a/src/main/java/com/example/taggo/domain/kakao/api/response/SearchResultResponse.java
+++ b/src/main/java/com/example/taggo/domain/kakao/api/response/SearchResultResponse.java
@@ -1,0 +1,31 @@
+package com.example.taggo.domain.kakao.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SearchResultResponse(
+
+        @JsonProperty("id")
+        String id,
+
+        @JsonProperty("place_name")
+        String placeName,
+
+        @JsonProperty("address_name")
+        String addressName,
+
+        @JsonProperty("road_address_name")
+        String roadAddress,
+
+        @JsonProperty("phone")
+        String phone,
+
+        @JsonProperty("place_url")
+        String placeUrl,
+
+        @JsonProperty("x")
+        String longitude,
+
+        @JsonProperty("y")
+        String latitude
+) {
+}

--- a/src/main/java/com/example/taggo/domain/kakao/service/KakaoApiService.java
+++ b/src/main/java/com/example/taggo/domain/kakao/service/KakaoApiService.java
@@ -1,0 +1,40 @@
+package com.example.taggo.domain.kakao.service;
+
+import com.example.taggo.domain.kakao.api.response.SearchResultListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoApiService {
+
+    @Value("${KAKAO_APP_KEY}")
+    private String key;
+    private String url = "https://dapi.kakao.com/v2/local/search/keyword.json";
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public SearchResultListResponse keywordSearch(String query) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.set("Authorization", "KakaoAK " + key);
+        HttpEntity<String> httpEntity = new HttpEntity<>(httpHeaders);
+        URI targetUri = UriComponentsBuilder
+                .fromUriString(url)
+                .queryParam("query", query)
+                .build()
+                .encode(StandardCharsets.UTF_8)
+                .toUri();
+
+        ResponseEntity<SearchResultListResponse> result = restTemplate.exchange(targetUri, HttpMethod.GET, httpEntity, SearchResultListResponse.class);
+        return result.getBody();
+    }
+}

--- a/src/main/java/com/example/taggo/domain/place/model/Place.java
+++ b/src/main/java/com/example/taggo/domain/place/model/Place.java
@@ -1,0 +1,40 @@
+package com.example.taggo.domain.place.model;
+
+import com.example.taggo.domain.common.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "place")
+public class Place extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private Long kakaoId;
+
+    private String name;
+
+//    private String address;
+//
+//    @Column(unique = true)
+//    private String phone;
+
+    public static Place create(Long kakaoId, String name){
+        return Place.builder()
+                .kakaoId(kakaoId)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/example/taggo/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/example/taggo/domain/place/repository/PlaceRepository.java
@@ -1,0 +1,10 @@
+package com.example.taggo.domain.place.repository;
+
+import com.example.taggo.domain.place.model.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+    Optional<Place> findByKakaoId(Long kakaoId);
+}

--- a/src/main/java/com/example/taggo/domain/place/service/PlaceService.java
+++ b/src/main/java/com/example/taggo/domain/place/service/PlaceService.java
@@ -1,0 +1,18 @@
+package com.example.taggo.domain.place.service;
+
+import com.example.taggo.domain.place.model.Place;
+import com.example.taggo.domain.place.repository.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceService {
+
+    private final PlaceRepository placeRepository;
+
+    public Place findOrCreate(Long kakaoId, String name){
+        return placeRepository.findByKakaoId(kakaoId).orElseGet(() ->
+                placeRepository.save(Place.create(kakaoId, name)));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- 관련된 이슈 번호: #8

---

## ✨ 변경 내용 요약

- 리뷰 및 즐겨찾기 등록 전, 가게를 먼저 데이터베이스에 저장하기 위해, 가게 도메인을 구현 하였습니다.

---

## 📸 스크린샷 (UI 변경 시)

<img width="566" alt="스크린샷 2025-05-13 오후 5 40 50" src="https://github.com/user-attachments/assets/04ac6d52-d487-4492-bc98-2a080b1c4e95" />

---

## 🔍 주요 체크리스트

- [x] 기존 기능에 영향이 없는지 확인
- [x] 테스트 코드 작성 및 통과 여부 확인
- [x] PR 설명 작성 완료
- [x] Merge 전 최종 리뷰 완료

---

## 🙋 기타 사항

- 현재 카카오 아이디, 가게 명 정도만 저장하고 있습니다.
- 추후에 즐겨찾기를 화면에 띄울때 정보가 어떻게 되느냐에 따라 가게 도메인도 변경이 필요할 것으로 보입니다.

